### PR TITLE
Add missing package declaration to distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(
     version='0.1',
     description='Command line script to synchronize Amazon Route53 DNS data.',
     package_dir={'': 'src'},
+    packages=['r53'],
     install_requires=[
         'boto',
         'lxml',


### PR DESCRIPTION
Through easy_install and pip, the r53 package is not included (just missing).
Declare it here so it will be included and prevent this:

```
[jed@js route53]$ r53
Traceback (most recent call last):
  File /usr/local/bin/r53, line 9, in <module>
    load_entry_point('r53==0.1', 'console_scripts', 'r53')()
  File /Library/Python/2.7/site-packages/distribute-0.6.24-py2.7.egg/pkg_resources.py, line 337, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File /Library/Python/2.7/site-packages/distribute-0.6.24-py2.7.egg/pkg_resources.py, line 2279, in load_entry_point
    return ep.load()
  File /Library/Python/2.7/site-packages/distribute-0.6.24-py2.7.egg/pkg_resources.py, line 1989, in load
    entry = __import__(self.module_name, globals(),globals(), ['__name__'])
ImportError: No module named r53.r53
```
